### PR TITLE
13 test coverage for model

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     id("org.jetbrains.compose")
 }
 
-group = "me.vkutuev"
-version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -24,8 +22,11 @@ dependencies {
     implementation(compose.desktop.currentOs)
     testRuntimeOnly("org.junit.platform:junit-platform-suite-engine:1.8.2")
     testImplementation("org.junit.platform:junit-platform-suite:1.13.0-M2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(kotlin("test"))
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.20")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/app/src/main/kotlin/model/Edge.kt
+++ b/app/src/main/kotlin/model/Edge.kt
@@ -1,6 +1,6 @@
 package model
 
-open class Edge<K, V, W>(start: Vertex<K, V>, end: Vertex<K, V>, var status: Status, var weight: W?=null) {
+open class Edge<K, V>(start: Vertex<K, V>, end: Vertex<K, V>, var status: Status, var weight: Int) {
     val link= Pair(start, end)
     companion object {
         enum class Status {

--- a/app/src/main/kotlin/model/Edge.kt
+++ b/app/src/main/kotlin/model/Edge.kt
@@ -1,11 +1,6 @@
 package model
 
-open class Edge<K, V>(start: Vertex<K, V>, end: Vertex<K, V>, var status: Status, var weight: Int) {
+open class Edge<K, V>(start: Vertex<K, V>, end: Vertex<K, V>, var weight: Int) {
     val link= Pair(start, end)
-    companion object {
-        enum class Status {
-            ONEDIRECTION,
-            BOTHDIRECTION
-        }
-    }
+
 }

--- a/app/src/main/kotlin/model/graphs/AbstractGraph.kt
+++ b/app/src/main/kotlin/model/graphs/AbstractGraph.kt
@@ -1,7 +1,6 @@
 package model.graphs
 
 import model.Edge
-import model.Edge.Companion.Status.BOTHDIRECTION
 import model.Vertex
 import java.util.Vector
 
@@ -16,22 +15,16 @@ abstract class AbstractGraph <K, V> {
         get()=_edges
 
 
-    open fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int,
-                     status: Edge.Companion.Status=BOTHDIRECTION) {
+    open fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
         if (!_vertices.map { it===first }.contains(true))
             addVertex(first)
         if (!_vertices.map { it===second }.contains(true))
             addVertex(second)
-        var edge= Edge<K, V>(first, second,status, weight)
+        var edge= Edge<K, V>(first, second, weight)
         _edges[edge.link.first]?.add(edge) ?: throw IllegalStateException()
-        if (edge.status==BOTHDIRECTION) {
-            edge= Edge<K, V>(second, first,status, weight)
-            _edges[edge.link.second]?.add(edge) ?: throw IllegalStateException()
-        }
     }
 
-    open fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>,
-                        status: Edge.Companion.Status=BOTHDIRECTION) {
+    open fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {
         if (!_vertices.map { it===first }.contains(true) || !_vertices.map { it===second }.contains(true))
             throw IllegalStateException()
         var current: Edge<K, V>?=null
@@ -40,14 +33,6 @@ abstract class AbstractGraph <K, V> {
             _edges[first]?.remove(current)
         else
             throw IllegalStateException()
-        if (status==BOTHDIRECTION) {
-            var current: Edge<K, V>?=null
-            _edges[first]?.forEach { if (it.link.second==second) current=it }
-            if (current!=null)
-                _edges[first]?.remove(current)
-            else
-                throw IllegalStateException()
-        }
     }
 
     fun addVertex(vertex: Vertex<K, V>) {
@@ -61,8 +46,7 @@ abstract class AbstractGraph <K, V> {
         if (!_vertices.map { it===vertex }.contains(true))
             return
         _edges[vertex]?.forEach {
-            if (it.status==BOTHDIRECTION)
-                _edges[it.link.second]?.remove(it)
+            _edges[it.link.second]?.remove(it)
         }
         _edges.remove(vertex)
         vertices.remove(vertex)

--- a/app/src/main/kotlin/model/graphs/DirWeightGraph.kt
+++ b/app/src/main/kotlin/model/graphs/DirWeightGraph.kt
@@ -1,4 +1,4 @@
 package model.graphs
 
-open class DirWeightGraph<K, V, W>: AbstractGraph<K, V, W>() {
+open class DirWeightGraph<K, V>: AbstractGraph<K, V>() {
 }

--- a/app/src/main/kotlin/model/graphs/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/DirectedGraph.kt
@@ -5,8 +5,8 @@ import model.Edge
 import model.Vertex
 
 
-class DirectedGraph<K, V, W>() : DirWeightGraph<K, V, W>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: W?, status: Edge.Companion.Status) {
-        super.addEdge(first, second, null, status)
+class DirectedGraph<K, V>() : DirWeightGraph<K, V>() {
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
+        super.addEdge(first, second, 0, status)
     }
 }

--- a/app/src/main/kotlin/model/graphs/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/DirectedGraph.kt
@@ -6,7 +6,7 @@ import model.Vertex
 
 
 class DirectedGraph<K, V>() : DirWeightGraph<K, V>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
-        super.addEdge(first, second, 0, status)
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
+        super.addEdge(first, second, 0)
     }
 }

--- a/app/src/main/kotlin/model/graphs/UndirWeightGraph.kt
+++ b/app/src/main/kotlin/model/graphs/UndirWeightGraph.kt
@@ -4,8 +4,8 @@ import model.Edge
 import model.Vertex
 import model.Edge.Companion.Status.BOTHDIRECTION
 
-open class UndirWeightGraph<K, V, W>: AbstractGraph<K, V, W>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: W?, status: Edge.Companion.Status) {
+open class UndirWeightGraph<K, V>: AbstractGraph<K, V>() {
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
         super<AbstractGraph>.addEdge(first, second, weight, BOTHDIRECTION)
     }
 

--- a/app/src/main/kotlin/model/graphs/UndirWeightGraph.kt
+++ b/app/src/main/kotlin/model/graphs/UndirWeightGraph.kt
@@ -2,15 +2,16 @@ package model.graphs
 
 import model.Edge
 import model.Vertex
-import model.Edge.Companion.Status.BOTHDIRECTION
 
 open class UndirWeightGraph<K, V>: AbstractGraph<K, V>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
-        super<AbstractGraph>.addEdge(first, second, weight, BOTHDIRECTION)
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
+        super.addEdge(first, second, weight)
+        super.addEdge(second, first, weight)
     }
 
-    override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>, status: Edge.Companion.Status) {
-        super.deleteEdge(first, second, BOTHDIRECTION)
+    override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {
+        super.deleteEdge(first, second)
+        super.deleteEdge(second, first)
     }
 
 }

--- a/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
@@ -2,14 +2,14 @@ package model.graphs
 
 import model.Edge
 import model.Vertex
-import model.Edge.Companion.Status.*
+
 
 class UndirectedGraph<K, V>: UndirWeightGraph<K, V>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
-        super.addEdge(first, second, 0, BOTHDIRECTION)
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
+        super.addEdge(first, second, 0)
     }
 
-    override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>, status: Edge.Companion.Status) {
-        super.deleteEdge(first, second, BOTHDIRECTION)
+    override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {
+        super.deleteEdge(first, second)
     }
 }

--- a/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
@@ -4,9 +4,9 @@ import model.Edge
 import model.Vertex
 import model.Edge.Companion.Status.*
 
-class UndirectedGraph<K, V, W>: UndirWeightGraph<K, V, W>() {
-    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: W?, status: Edge.Companion.Status) {
-        super.addEdge(first, second, null, BOTHDIRECTION)
+class UndirectedGraph<K, V>: UndirWeightGraph<K, V>() {
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int, status: Edge.Companion.Status) {
+        super.addEdge(first, second, 0, BOTHDIRECTION)
     }
 
     override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>, status: Edge.Companion.Status) {

--- a/app/src/test/kotlin/model/GraphTest.kt
+++ b/app/src/test/kotlin/model/GraphTest.kt
@@ -1,0 +1,45 @@
+package model
+
+import model.graphs.AbstractGraph
+import model.graphs.DirWeightGraph
+import model.graphs.DirectedGraph
+import model.graphs.UndirWeightGraph
+import model.graphs.UndirectedGraph
+import org.junit.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.stream.Stream
+import kotlin.random.Random
+import kotlin.reflect.KClass
+import kotlin.reflect.full.*
+import kotlin.test.assertEquals
+
+
+class GraphTest {
+
+    companion object {
+        val constructors=arrayOf(DirectedGraph::class, DirWeightGraph::class, UndirWeightGraph::class, UndirectedGraph::class)
+        @JvmStatic fun generateVertices(): Stream<Arguments> {
+            return Stream.generate {
+                val numb=Random.nextInt(0,1000)
+                val array= Array<Vertex<Int, Int>?>(numb) {null}
+                for (i in 0..<numb)
+                    array[i]= Vertex(Random.nextInt(), Random.nextInt())
+                Arguments.of(numb, array,constructors.random())
+            }.limit(1000)
+        }
+    }
+
+    @ParameterizedTest(name = "{0} vertices for {2}")
+    @MethodSource("generateVertices")
+    fun `test vertex insertion`(amount: Int, array: Array<Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
+        var graph= kClass.primaryConstructor?.call()
+        for (i in array)
+            graph?.addVertex(i)
+        assertEquals(amount, graph?.vertices?.size)
+    }
+}

--- a/app/src/test/kotlin/model/GraphTest.kt
+++ b/app/src/test/kotlin/model/GraphTest.kt
@@ -1,6 +1,5 @@
 package model
 
-import androidx.compose.ui.unit.sp
 import model.graphs.AbstractGraph
 import model.graphs.DirWeightGraph
 import model.graphs.DirectedGraph
@@ -9,10 +8,7 @@ import model.graphs.UndirectedGraph
 import org.junit.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsSource
-import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
-import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 import kotlin.math.min
 import kotlin.random.Random
@@ -23,33 +19,7 @@ import kotlin.test.assertEquals
 
 class GraphTest {
 
-    companion object {
-        val constructors=arrayOf(DirectedGraph::class, DirWeightGraph::class, UndirWeightGraph::class, UndirectedGraph::class)
-        @JvmStatic fun generateVertices(): Stream<Arguments> {
-            return Stream.generate {
-                val numb=Random.nextInt(1,1000)
-                val array= HashMap< Int, Vertex<Int, Int>?>(numb)
-                for (i in 0..<numb)
-                    array[i]= Vertex(Random.nextInt(), Random.nextInt())
-                Arguments.of(numb, array,constructors.random())
-            }.limit(1000)
-        }
-
-    }
-
-    @ParameterizedTest(name = "{0} vertices for {2}")
-    @MethodSource("generateVertices")
-    fun `test vertex insertion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
-        var graph= kClass.primaryConstructor?.call()
-        for (i in map.values)
-            graph?.addVertex(i)
-        assertEquals(amount, graph?.vertices?.size)
-    }
-
-    @ParameterizedTest(name = "{0} vertices to make edges for {2}")
-    @MethodSource("generateVertices")
-    fun `test edge insertion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
-        var graph= kClass.primaryConstructor?.call()
+    fun edgeAddition(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, graph: AbstractGraph<Int, Int>): IntArray {
         var array= IntArray(map.keys.size)
         var t=min(2000, amount*amount/2)
         for (i in 1..t) {
@@ -57,14 +27,43 @@ class GraphTest {
             var second=map.keys.random()
             if (first==second)
                 continue
-            graph?.addEdge(map[first] ?: continue, map[second] ?: continue, Random.nextInt())
-            if (kClass.simpleName in arrayOf("UndirectedGraph", "UndirWeightGraph"))
+            graph.addEdge(map[first] ?: continue, map[second] ?: continue, Random.nextInt())
+            if (graph::class.simpleName in arrayOf("UndirectedGraph", "UndirWeightGraph"))
                 array[second]++
             array[first]++
         }
+        return array
+    }
 
+    companion object {
+        val constructors=arrayOf(DirectedGraph::class, DirWeightGraph::class, UndirWeightGraph::class, UndirectedGraph::class)
+        @JvmStatic fun generateVertices(): Stream<Arguments> {
+            return Stream.generate {
+                val numb=Random.nextInt(1,1000)
+                val map= HashMap< Int, Vertex<Int, Int>?>(numb)
+                for (i in 0..<numb)
+                    map[i]= Vertex(Random.nextInt(), Random.nextInt())
+                Arguments.of(numb, map,constructors.random())
+            }.limit(250)
+        }
+    }
+
+    @ParameterizedTest(name = "{0} vertices for {2}")
+    @MethodSource("generateVertices")
+    fun `test vertex insertion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
+        val graph= kClass.primaryConstructor?.call() ?: return
+        for (i in map.values)
+            graph.addVertex(i)
+        assertEquals(amount, graph.vertices.size)
+    }
+
+    @ParameterizedTest(name = "{0} vertices to make edges for {2}")
+    @MethodSource("generateVertices")
+    fun `test edge insertion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
+        var graph= kClass.primaryConstructor?.call() ?: return
+        var array=edgeAddition(amount, map, graph)
         for (i in 0..<array.size)
-            assertEquals(array[i], graph?.edges?.get(map[i])?.size ?: 0)
+            assertEquals(array[i], graph.edges[map[i]]?.size ?: 0)
     }
 
     @ParameterizedTest(name = "{0} vertices to delete some from {2}")
@@ -81,6 +80,33 @@ class GraphTest {
             map.remove(cur)
         }
         assertEquals(amount-expected, graph?.vertices?.size ?: 0)
+    }
+
+
+    @ParameterizedTest(name = "{0} vertices to delete edges from {2}")
+    @MethodSource("generateVertices")
+    fun `test edge deletion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
+        var graph=kClass.primaryConstructor?.call() ?: return
+        var array=edgeAddition(amount, map, graph)
+        var repetitions=Random.nextInt(-1, array.sum())
+        for (i in 1..repetitions) {
+            if (graph.edges.keys.isEmpty())
+                break
+            var vector=graph.edges[map[array.indices.random()]]
+            var current: Edge<Int, Int>?=null
+            if (vector?.isNotEmpty() == true)
+                current=vector.random()
+            map.forEach {
+                if (it.value===current?.link?.first)
+                    array[it.key]--
+                when(kClass.simpleName) {
+                   "UndirWeightGraph", "UndirectedGraph" -> if (it.value===current?.link?.second) array[it.key]--
+                }
+            }
+            graph.deleteEdge(current?.link?.first ?: continue, current.link.second)
+        }
+        for (i in 0..<array.size)
+            assertEquals(array[i], graph.edges[map[i]]?.size ?: 0)
     }
 
 }

--- a/app/src/test/kotlin/model/GraphTest.kt
+++ b/app/src/test/kotlin/model/GraphTest.kt
@@ -27,13 +27,14 @@ class GraphTest {
         val constructors=arrayOf(DirectedGraph::class, DirWeightGraph::class, UndirWeightGraph::class, UndirectedGraph::class)
         @JvmStatic fun generateVertices(): Stream<Arguments> {
             return Stream.generate {
-                val numb=Random.nextInt(0,1000)
+                val numb=Random.nextInt(1,1000)
                 val array= HashMap< Int, Vertex<Int, Int>?>(numb)
                 for (i in 0..<numb)
                     array[i]= Vertex(Random.nextInt(), Random.nextInt())
                 Arguments.of(numb, array,constructors.random())
             }.limit(1000)
         }
+
     }
 
     @ParameterizedTest(name = "{0} vertices for {2}")
@@ -45,7 +46,7 @@ class GraphTest {
         assertEquals(amount, graph?.vertices?.size)
     }
 
-    @ParameterizedTest(name = "{0} edges for {2}")
+    @ParameterizedTest(name = "{0} vertices to make edges for {2}")
     @MethodSource("generateVertices")
     fun `test edge insertion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
         var graph= kClass.primaryConstructor?.call()
@@ -64,10 +65,22 @@ class GraphTest {
 
         for (i in 0..<array.size)
             assertEquals(array[i], graph?.edges?.get(map[i])?.size ?: 0)
-
-        /*when(kClass.simpleName) {
-            "UndirectedGraph", "UndirWeightGraph" -> graph?.edges?.values?.forEach { it.forEach { assertEquals(0, it.weight) } }
-        }*/
-
     }
+
+    @ParameterizedTest(name = "{0} vertices to delete some from {2}")
+    @MethodSource("generateVertices")
+    fun `test vertex deletion`(amount: Int, map: HashMap<Int, Vertex<Int, Int>>, kClass: KClass<AbstractGraph<Int, Int>>) {
+        var graph=kClass.primaryConstructor?.call()
+        for (i in map.values)
+            graph?.addVertex(i)
+        var expected=Random.nextInt(0, amount)
+        repeat(expected) {
+            var cur=map.keys.random()
+            graph?.deleteVertex(map[cur]!!)
+            assert(graph?.edges?.get(map[cur])==null)
+            map.remove(cur)
+        }
+        assertEquals(amount-expected, graph?.vertices?.size ?: 0)
+    }
+
 }


### PR DESCRIPTION
* change of model classes: due to complexity of variant with enum object control of graph direction, exclude it, and change to double invocation if method for indirected graphs 
* complite test classes for correctness of model classes
Closes #13  