### PR TITLE
new graph interfaces

### DIFF
--- a/app/src/main/kotlin/model/graphs/AbstractGraph.kt
+++ b/app/src/main/kotlin/model/graphs/AbstractGraph.kt
@@ -21,8 +21,7 @@ abstract class AbstractGraph <K, V>: Graph<K, V> {
         if (!_vertices.map { it===second }.contains(true))
             addVertex(second)
         var edge= Edge<K, V>(first, second, weight)
-        if (_edges[edge.link.first]?.map { it.link.second==second }?.contains(true) != true)
-            _edges[edge.link.first]?.add(edge) ?: throw IllegalStateException()
+        _edges[first]?.add(edge) ?: throw IllegalStateException()
     }
 
     override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {

--- a/app/src/main/kotlin/model/graphs/AbstractGraph.kt
+++ b/app/src/main/kotlin/model/graphs/AbstractGraph.kt
@@ -4,7 +4,7 @@ import model.Edge
 import model.Vertex
 import java.util.Vector
 
-abstract class AbstractGraph <K, V> {
+abstract class AbstractGraph <K, V>: Graph<K, V> {
     protected var _vertices= Vector<Vertex<K, V>>()
     protected var _edges= hashMapOf<Vertex<K, V>, Vector<Edge<K, V>>>()
 
@@ -15,16 +15,17 @@ abstract class AbstractGraph <K, V> {
         get()=_edges
 
 
-    open fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
+    override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
         if (!_vertices.map { it===first }.contains(true))
             addVertex(first)
         if (!_vertices.map { it===second }.contains(true))
             addVertex(second)
         var edge= Edge<K, V>(first, second, weight)
-        _edges[edge.link.first]?.add(edge) ?: throw IllegalStateException()
+        if (_edges[edge.link.first]?.map { it.link.second==second }?.contains(true) != true)
+            _edges[edge.link.first]?.add(edge) ?: throw IllegalStateException()
     }
 
-    open fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {
+    override fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>) {
         if (!_vertices.map { it===first }.contains(true) || !_vertices.map { it===second }.contains(true))
             throw IllegalStateException()
         var current: Edge<K, V>?=null
@@ -35,12 +36,12 @@ abstract class AbstractGraph <K, V> {
             throw IllegalStateException()
     }
 
-    internal fun addVertex(vertex: Vertex<K, V>) {
+    override fun addVertex(vertex: Vertex<K, V>) {
         vertices.add(vertex)
         _edges[vertex]= Vector()
     }
 
-    fun deleteVertex(vertex: Vertex<K, V>) {
+    override fun deleteVertex(vertex: Vertex<K, V>) {
         if (!_vertices.map { it===vertex }.contains(true))
             return
         _edges[vertex]?.forEach {

--- a/app/src/main/kotlin/model/graphs/DirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/DirectedGraph.kt
@@ -1,11 +1,9 @@
 package model.graphs
 
-
-import model.Edge
 import model.Vertex
 
 
-class DirectedGraph<K, V>() : DirWeightGraph<K, V>() {
+class DirectedGraph<K, V>() : DirWeightGraph<K, V>(), NoWeightGraph<K, V> {
     override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
         super.addEdge(first, second, 0)
     }

--- a/app/src/main/kotlin/model/graphs/Graph.kt
+++ b/app/src/main/kotlin/model/graphs/Graph.kt
@@ -1,0 +1,10 @@
+package model.graphs
+
+import model.Vertex
+
+interface Graph <K, V> {
+    fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int)
+    fun deleteEdge(first: Vertex<K, V>, second: Vertex<K, V>)
+    fun addVertex(vertex: Vertex<K, V>)
+    fun deleteVertex(vertex: Vertex<K, V>)
+}

--- a/app/src/main/kotlin/model/graphs/NoWeightGraph.kt
+++ b/app/src/main/kotlin/model/graphs/NoWeightGraph.kt
@@ -1,0 +1,4 @@
+package model.graphs
+
+interface NoWeightGraph<K, V>: Graph<K, V> {
+}

--- a/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
+++ b/app/src/main/kotlin/model/graphs/UndirectedGraph.kt
@@ -1,10 +1,9 @@
 package model.graphs
 
-import model.Edge
 import model.Vertex
 
 
-class UndirectedGraph<K, V>: UndirWeightGraph<K, V>() {
+class UndirectedGraph<K, V>: UndirWeightGraph<K, V>(), NoWeightGraph<K, V> {
     override fun addEdge(first: Vertex<K, V>, second: Vertex<K, V>, weight: Int) {
         super.addEdge(first, second, 0)
     }

--- a/app/src/test/kotlin/model/GraphTest.kt
+++ b/app/src/test/kotlin/model/GraphTest.kt
@@ -15,7 +15,7 @@ import kotlin.random.Random
 import kotlin.reflect.KClass
 import kotlin.reflect.full.*
 import kotlin.test.assertEquals
-
+import algorithms.FordBellmanTest
 
 class GraphTest {
 
@@ -32,8 +32,10 @@ class GraphTest {
                 array[second]++
             array[first]++
         }
+
         return array
     }
+
 
     companion object {
         val constructors=arrayOf(DirectedGraph::class, DirWeightGraph::class, UndirWeightGraph::class, UndirectedGraph::class)


### PR DESCRIPTION
change graph type hierarchy: add interface for graphs with no weights on edges, so they could be refereed similarly
fix double edge between two nodes insertion: only one node can now exist between two  
Closed #16 